### PR TITLE
Fix bato.si chapter pagination using start=-1

### DIFF
--- a/src/scraper/chapters.py
+++ b/src/scraper/chapters.py
@@ -46,8 +46,13 @@ def fetch_chapters(manga_url: str) -> List[Chapter]:
     logger.debug(f"Fetching chapters from: {manga_url}")
     
     # Ensure we're fetching from the chapters section
-    if '?' not in manga_url:
-        manga_url = f"{manga_url}?start=1#chapters"
+
+    # NOTE:
+    # bato.si paginates chapter listings in batches of 100 using the `start` query parameter.
+    # While `start=1`, `start=101`, etc. return paginated results, testing shows that
+    # `start=-1` returns the full chapter list in a single response.
+    
+    manga_url = f"{manga_url.split('?', 1)[0]}?start=-1"
     
     resp = requests.get(manga_url, headers=HEADERS, timeout=30)
     resp.raise_for_status()


### PR DESCRIPTION
### Summary
Fixes an issue where bato.si manga with more than 100 chapters
only returned the first page of chapters.

### Details
bato.si paginates chapter listings using the `start` query parameter
(e.g. start=1, start=101, etc).

Testing shows that using `start=-1` returns the full chapter list
in a single response. This change updates `fetch_chapters()` to use
that behavior.

### Changes
- Modified `manga_url` to use `start=-1`
- Added inline documentation explaining bato.si behavior

### Testing
- Tested on multiple bato.si manga with >100 chapters
- All chapters were returned correctly in a single request